### PR TITLE
Fix negative note jump movement speed condition in NegativeNJSOverrideHooks

### DIFF
--- a/src/Hooks/NegativeNJSOverrideHooks.cpp
+++ b/src/Hooks/NegativeNJSOverrideHooks.cpp
@@ -11,7 +11,7 @@ MAKE_AUTO_HOOK_MATCH(BeatmapDifficultyMethods_NoteJumpMovementSpeed, &GlobalName
 {
     float result = BeatmapDifficultyMethods_NoteJumpMovementSpeed(difficulty, noteJumpMovementSpeed, fastNotes);
 
-    if(noteJumpMovementSpeed <= GlobalNamespace::VariableMovementDataProvider::kMinNoteJumpMovementSpeed)
+    if(noteJumpMovementSpeed <= -GlobalNamespace::VariableMovementDataProvider::kMinNoteJumpMovementSpeed)
     {
         result = noteJumpMovementSpeed;
     }


### PR DESCRIPTION
Hook was incorrectly ported from PC and checking for < 0.01 rather than < -0.01